### PR TITLE
New branch testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # **Simple** E2E test suite with Cypress
 [![cypress-example](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/detailed/urshkd&style=flat&logo=cypress)](https://dashboard.cypress.io/projects/urshkd/runs) [![cypress-example](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/count/urshkd&style=flat&logo=cypress)](https://dashboard.cypress.io/projects/urshkd/runs)
-> **application under test:** http://angularjs.realworld.io/
+
+> **application under test:** https://github.com/marcusAutomation/securitas_cypress/tree/new_branch
 
 ## :goal_net: Goals
 - keep it simple - no 'custom' abstractions/functions/utils/helpers (use what Cypress provides)
@@ -13,7 +14,7 @@
 
 ## :gear: Setup
 
-1. `git clone https://github.com/helenanull/cypress-example.git`
+1. `https://github.com/marcusAutomation/securitas_cypress`
 2. cd to `cypress-example` folder and run `npm install`
 
 

--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -8,22 +8,28 @@ describe('Login', () => {
     
     context('unsuccessful', () => {
         beforeEach(() => {
-            
+
             // baseUrl is set in config - cypress.json file
             cy.visit('')
         })
 
         it('can I click on the aceptar continue button?', () => {
             
+            // As I user I able to click on Aceptar and Continuar button
+            login_access.click_on_aceptar_continuar_button()
+            // Then I wait to the pup up dialog completlly disapear
+            cy.wait(1000)
+            // Then I click on the login button
+            login_access.click_on_area_client_button()
 
-             login_access.click_on_aceptar_continuar_button()
-             cy.wait(1000)
-             login_access.click_on_area_client_button()
-             cy.origin("https://customers.securitasdirect.es", () => {
+        })
+
+        it('should allow me to click on login button', () => {
+            // Then I access the login page
+            cy.origin("https://customers.securitasdirect.es", () => {
                 cy.visit("/owa-static/login") 
-             })
-        
-            
+            })
+
         })
 
     })

--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -6,7 +6,7 @@ describe('Login', () => {
     const login_access = new Loginn()
 
     
-    context('unsuccessful', () => {
+    context('successful login', () => {
         beforeEach(() => {
 
             // baseUrl is set in config - cypress.json file


### PR DESCRIPTION
## What?
I've added support for authentication to implement Key Result 2 of OKR1. It includes model, table, controller and test. For more background, see ticket 
#JIRA-123.
## Why?
These changes complete the user login and account creation experience. See #JIRA-123 for more information.
## How?
This includes a migration, model and controller for user authentication. I'm using Devise to do the heavy lifting. I ran Devise migrations and those are included here.
## Testing?
I've added coverage for testing all new methods. I used Faker for a few random user emails and names.
## Screenshots (optional)
0
## Anything Else?
Let's consider using a 3rd party authentication provider for this, to offload MFA and other considerations as they arise and as the privacy landscape evolves. AWS Cognito is a good option, so is Firebase. I'm happy to start researching this path. Let's also consider breaking this out into its own service. We can then re-use it or share the accounts with other apps in the future.